### PR TITLE
Update metadata.json for Gnome Shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "Luna - Moon Phase Indicator",
   "description": "Displays current moon phase, and illumination.",
-  "shell-version": ["46"],
+  "shell-version": ["46", "48"],
   "original-author": "roy.thande@gmail.com",
   "url": "https://github.com/thanderoy/luna",
   "uuid": "luna@thanderoy.github.io",


### PR DESCRIPTION
I tested it under Fedora 42 with Gnome Shell 48 and it works.

## Summary by Sourcery

Enhancements:
- Added compatibility with Gnome Shell 48