### PR TITLE
feat: Switch to FarmSense API for Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Luna is a simple GNOME Shell extension that displays the current moon phase dire
   - Current phase name
   - Next phase
   - Illumination percentage
+  - Distance (Meridian)
+  - Age of the moon phase
 - Refresh button for manual updates
 - Updates automatically every hour
 - Lightweight and unobtrusive

--- a/contants.js
+++ b/contants.js
@@ -1,0 +1,42 @@
+export const UPDATE_INTERVAL_SECONDS = 3600; // Update every hour
+export const ICON_SIZE = 16; // Icon size in pixels
+export const API_URL = 'https://api.farmsense.net/v1/moonphases/?d=';
+
+// Moon phase constants
+export const MOON_PHASES = Object.freeze({
+    NEW_MOON: 'New Moon',
+    WAXING_CRESCENT: 'Waxing Crescent',
+    FIRST_QUARTER: 'First Quarter',
+    WAXING_GIBBOUS: 'Waxing Gibbous',
+    FULL_MOON: 'Full Moon',
+    WANING_GIBBOUS: 'Waning Gibbous',
+    LAST_QUARTER: 'Last Quarter',
+    WANING_CRESCENT: 'Waning Crescent'
+});
+
+// Map phase names to icon filenames
+export const PHASE_ICONS = Object.freeze({
+    [MOON_PHASES.NEW_MOON]: 'luna_nueva',
+    [MOON_PHASES.WAXING_CRESCENT]: 'luna_creciente',
+    [MOON_PHASES.FIRST_QUARTER]: 'luna_cuarto_creciente',
+    [MOON_PHASES.WAXING_GIBBOUS]: 'luna_gibosa_creciente',
+    [MOON_PHASES.FULL_MOON]: 'luna_llena',
+    [MOON_PHASES.WANING_GIBBOUS]: 'luna_gibosa_menguante',
+    [MOON_PHASES.LAST_QUARTER]: 'luna_cuarto_menguante',
+    [MOON_PHASES.WANING_CRESCENT]: 'luna_menguante'
+});
+
+// API Phase Names mapping
+export const API_PHASE_NAMES = Object.freeze({
+    'New Moon': MOON_PHASES.NEW_MOON,
+    'Waxing Crescent': MOON_PHASES.WAXING_CRESCENT,
+    '1st Quarter': MOON_PHASES.FIRST_QUARTER,
+    'Waxing Gibbous': MOON_PHASES.WAXING_GIBBOUS,
+    'Full Moon': MOON_PHASES.FULL_MOON,
+    'Waning Gibbous': MOON_PHASES.WANING_GIBBOUS,
+    '3rd Quarter': MOON_PHASES.LAST_QUARTER,
+    'Waning Crescent': MOON_PHASES.WANING_CRESCENT,
+});
+
+// Convert phase names to array for indexing
+export const PHASE_NAMES = Object.values(MOON_PHASES);

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
   "name": "Luna - Moon Phase Indicator",
   "description": "Displays current moon phase, and illumination.",
-  "shell-version": ["46", "48"],
+  "shell-version": ["46", "47", "48"],
   "original-author": "roy.thande@gmail.com",
   "url": "https://github.com/thanderoy/luna",
   "uuid": "luna@thanderoy.github.io",
-  "version": 1,
+  "version": 4,
   "donations": {"buymeacoffee": "thanderoy"}
 }

--- a/moonPhaseIndicator.js
+++ b/moonPhaseIndicator.js
@@ -1,0 +1,157 @@
+import GObject from 'gi://GObject';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import St from 'gi://St';
+import Soup from 'gi://Soup';
+
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+
+import { CustomPopupMenu } from './ui/customPopupMenu.js';
+import { RefreshButton } from './ui/refreshButton.js';
+import {
+    UPDATE_INTERVAL_SECONDS,
+    ICON_SIZE,
+    API_URL,
+    MOON_PHASES,
+    PHASE_ICONS,
+    API_PHASE_NAMES,
+    PHASE_NAMES
+} from './constants.js';
+
+export const MoonPhaseIndicator = GObject.registerClass(
+class MoonPhaseIndicator extends PanelMenu.Button {
+    _init(extension) {
+        super._init(0.0, 'Moon Phase Indicator');
+
+        this._extension = extension;
+        this._httpSession = null;
+        this._initHttpSession();
+
+        this.moon_phase_icon = new St.Icon({
+            icon_name: 'weather-clear-night-symbolic', // Fallback icon
+            style_class: 'system-status-icon',
+            icon_size: ICON_SIZE
+        });
+        this.add_child(this.moon_phase_icon);
+
+        this._buildMenu();
+
+        this._updateMoonPhase();
+        this._startTimer();
+    }
+
+    _initHttpSession() {
+        if (this._httpSession === null) {
+            this._httpSession = new Soup.Session();
+            this._httpSession.user_agent = 'Luna - Moon Phase Indicator';
+        }
+    }
+
+    _startTimer() {
+        this._stopTimer();
+
+        this._timerId = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT,
+            UPDATE_INTERVAL_SECONDS,
+            () => {
+                this._updateMoonPhase();
+                return GLib.SOURCE_CONTINUE;
+            }
+        );
+    }
+
+    _stopTimer() {
+        if (this._timerId) {
+            GLib.source_remove(this._timerId);
+            this._timerId = null;
+        }
+    }
+
+    _buildMenu() {
+        this._styledMenuItem = new CustomPopupMenu();
+        this.menu.addMenuItem(this._styledMenuItem);
+
+        this._refreshButton = new RefreshButton(() => {
+            this._updateMoonPhase();
+        });
+        this.menu.addMenuItem(this._refreshButton);
+    }
+
+    _updateMoonPhase() {
+        const now = Math.floor(Date.now() / 1000);
+
+        const url = API_URL + now;
+
+        let request = Soup.Message.new('GET', url);
+
+        this._httpSession.send_and_read_async(
+            request,
+            GLib.PRIORITY_DEFAULT,
+            null,
+            this._onMoonDataReceived.bind(this)
+        );
+
+        return true;
+    }
+
+    _onMoonDataReceived(session, result) {
+        const bytes = session.send_and_read_finish(result);
+        if (bytes === null) {
+            console.error('Failed to get moon phase data');
+            return;
+        }
+
+        const decoder = new TextDecoder('utf-8');
+        const data = decoder.decode(bytes.get_data());
+
+        const moonData = JSON.parse(data)[0];
+
+        if (moonData.Error !== 0) {
+            console.error(`API Error: ${moonData.ErrorMsg}`);
+            return;
+        }
+
+        this._updateUI(moonData);
+
+    }
+
+
+    _updateUI(moonData) {
+        const apiPhaseName = moonData.Phase;
+        const illumination = moonData.Illumination;
+        const moonAge = moonData.Age;
+        const moonDistance = moonData.Distance;
+
+        const phaseName = API_PHASE_NAMES[apiPhaseName] || MOON_PHASES.NEW_MOON;
+
+        const iconName = PHASE_ICONS[phaseName] || PHASE_ICONS[MOON_PHASES.NEW_MOON];
+        const iconPath = `${this._extension.path}/icons/${iconName}.svg`;
+
+        if (GLib.file_test(iconPath, GLib.FileTest.EXISTS)) {
+            this.moon_phase_icon.gicon = Gio.icon_new_for_string(iconPath);
+        } else {
+            console.warn(`Moon phase icon not found: ${iconPath}`);
+            this.moon_phase_icon.icon_name = 'weather-clear-night-symbolic';
+        }
+
+        const nextPhaseIndex = (PHASE_NAMES.indexOf(phaseName) + 1) % PHASE_NAMES.length;
+        const nextPhaseName = PHASE_NAMES[nextPhaseIndex];
+
+        this._styledMenuItem.updateData({
+            phaseName: phaseName,
+            illumination: Math.round(illumination * 100),
+            nextPhase: nextPhaseName,
+            distance: Math.round(moonDistance).toLocaleString(),
+            age: moonAge.toFixed(2)
+        });
+    }
+
+    destroy() {
+        this._stopTimer();
+        if (this._httpSession !== null) {
+            this._httpSession.abort();
+            this._httpSession = null;
+        }
+        super.destroy();
+    }
+});

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -1,0 +1,60 @@
+.moon-phase-menu {
+    padding: 8px;
+}
+
+/* Header styles */
+.header-label {
+    font-size: 12px;
+    color: #aaa;
+    text-align: center;
+    width: 100%;
+}
+
+.phase-label {
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+}
+
+.illumination-label {
+    font-size: 12px;
+    color: #ccc;
+    text-align: center;
+    width: 100%;
+}
+
+/* Information rows */
+.info-box {
+    margin-top: 4px;
+}
+
+.info-label {
+    font-size: 12px;
+    color: #aaa;
+}
+
+.info-value {
+    font-size: 14px;
+    font-weight: bold;
+}
+
+/* Separator */
+.separator {
+    height: 1px;
+    background-color: rgba(255 255 255 / 50%);
+    margin: 8px 0;
+}
+
+/* Refresh button */
+.refresh-button {
+    border-radius: 4px;
+    font-weight: bold;
+    padding: 8px 16px;
+    background-color: rgba(255 255 255 / 10%);
+    color: #fff;
+}
+
+.refresh-button:hover {
+    background-color: rgba(255 255 255 / 20%);
+}

--- a/ui/customPopupMenu.js
+++ b/ui/customPopupMenu.js
@@ -1,0 +1,158 @@
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+export const CustomPopupMenu = GObject.registerClass(
+class CustomPopupMenu extends PopupMenu.PopupBaseMenuItem {
+    _init() {
+        super._init({
+            reactive: false,
+            can_focus: false,
+            style_class: 'styled-menu-item moon-phase-menu'
+        });
+
+        // Container for all content
+        this.container = new St.BoxLayout({
+            vertical: true,
+            x_expand: true,
+            style_class: 'styled-container'
+        });
+        this.add_child(this.container);
+
+        // Current Phase Label
+        this.headerLabel = new St.Label({
+            text: 'CURRENT PHASE:',
+            style_class: 'header-label',
+            x_align: Clutter.ActorAlign.CENTER
+        });
+        this.container.add_child(this.headerLabel);
+
+        // Current Phase Value
+        this.phaseLabel = new St.Label({
+            text: '',
+            style_class: 'phase-label',
+            x_align: Clutter.ActorAlign.CENTER
+        });
+        this.container.add_child(this.phaseLabel);
+
+        // Illumination info
+        this.illuminationLabel = new St.Label({
+            text: '',
+            style_class: 'illumination-label',
+            x_align: Clutter.ActorAlign.CENTER
+        });
+        this.container.add_child(this.illuminationLabel);
+
+        // Next phase section
+        this.nextPhaseBox = new St.BoxLayout({
+            style_class: 'next-phase-box info-box',
+            x_expand: true
+        });
+        this.container.add_child(this.nextPhaseBox);
+
+        this.nextPhaseLabel = new St.Label({
+            text: 'NEXT PHASE:',
+            style_class: 'next-phase-label info-label',
+            x_expand: true,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.nextPhaseBox.add_child(this.nextPhaseLabel);
+
+        this.nextPhaseValue = new St.Label({
+            text: '',
+            style_class: 'next-phase-value info-value',
+            x_expand: false,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.nextPhaseBox.add_child(this.nextPhaseValue);
+
+        // Separator
+        this.separator = new St.BoxLayout({
+            style_class: 'separator'
+        });
+        this.container.add_child(this.separator);
+
+        // Distance section
+        this.distanceBox = new St.BoxLayout({
+            style_class: 'distance-box info-box',
+            x_expand: true
+        });
+        this.container.add_child(this.distanceBox);
+
+        this.distanceLabel = new St.Label({
+            text: 'DISTANCE:',
+            style_class: 'distance-label info-label',
+            x_expand: true,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.distanceBox.add_child(this.distanceLabel);
+
+        this.distanceValue = new St.Label({
+            text: '',
+            style_class: 'distance-value info-value',
+            x_expand: false,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.distanceBox.add_child(this.distanceValue);
+
+        // Age section
+        this.ageBox = new St.BoxLayout({
+            style_class: 'age-box info-box',
+            x_expand: true
+        });
+        this.container.add_child(this.ageBox);
+
+        this.ageLabel = new St.Label({
+            text: 'AGE:',
+            style_class: 'age-label info-label',
+            x_expand: true,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.ageBox.add_child(this.ageLabel);
+
+        this.ageValue = new St.Label({
+            text: '',
+            style_class: 'age-value info-value',
+            x_expand: false,
+            y_align: Clutter.ActorAlign.CENTER
+        });
+        this.ageBox.add_child(this.ageValue);
+
+        // Final separator
+        this.separator2 = new St.BoxLayout({
+            style_class: 'separator'
+        });
+        this.container.add_child(this.separator2);
+    }
+
+    updateData(data) {
+        if (!data) return;
+
+        if (data.phaseName) this.phaseLabel.text = data.phaseName;
+        if (data.illumination) this.illuminationLabel.text = `(Illumination: ${data.illumination}%)`;
+        if (data.nextPhase) this.nextPhaseValue.text = data.nextPhase;
+        if (data.distance) this.distanceValue.text = `${data.distance} km`;
+        if (data.age) this.ageValue.text = `${data.age} Days`;
+    }
+
+    setPhase(phaseName) {
+        this.phaseLabel.text = phaseName;
+    }
+
+    setIllumination(value) {
+        this.illuminationLabel.text = `(Illumination: ${value}%)`;
+    }
+
+    setNextPhase(phaseName) {
+        this.nextPhaseValue.text = phaseName;
+    }
+
+    setDistance(distance) {
+        this.distanceValue.text = `${distance} km`;
+    }
+
+    setAge(age) {
+        this.ageValue.text = `${age} Days`;
+    }
+});

--- a/ui/refreshButton.js
+++ b/ui/refreshButton.js
@@ -1,0 +1,29 @@
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+export const RefreshButton = GObject.registerClass(
+class RefreshButton extends PopupMenu.PopupBaseMenuItem {
+    _init(callback) {
+        super._init({
+            style_class: 'refresh-button-item',
+        });
+
+        const buttonBox = new St.BoxLayout({
+            x_expand: true,
+            style_class: 'refresh-button-box',
+            x_align: Clutter.ActorAlign.CENTER
+        });
+        this.add_child(buttonBox);
+
+        this.button = new St.Button({
+            label: 'Refresh',
+            style_class: 'refresh-button',
+            x_align: Clutter.ActorAlign.CENTER
+        });
+
+        this.button.connect('clicked', callback);
+        buttonBox.add_child(this.button);
+    }
+});


### PR DESCRIPTION
## Summary by Sourcery

Switch the moon phase indicator to use the FarmSense API for more accurate and detailed moon phase information

New Features:
- Fetch moon phase data from FarmSense API
- Add moon distance and age information to the indicator
- Implement a more detailed and styled popup menu for moon phase details

Enhancements:
- Redesign the menu layout with more comprehensive moon phase information
- Improve error handling for API requests
- Add a custom refresh button

Chores:
- Replace local moon phase calculation with API-driven approach